### PR TITLE
[#1]; feat: 회원가입 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    runtimeOnly 'com.h2database:h2'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/sennyru/onboarding/config/SecurityConfig.java
+++ b/src/main/java/com/sennyru/onboarding/config/SecurityConfig.java
@@ -2,14 +2,31 @@ package com.sennyru.onboarding.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/members/signup", "/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
+
+        return http.build();
     }
 }

--- a/src/main/java/com/sennyru/onboarding/config/SecurityConfig.java
+++ b/src/main/java/com/sennyru/onboarding/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.sennyru.onboarding.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/config/SecurityConfig.java
+++ b/src/main/java/com/sennyru/onboarding/config/SecurityConfig.java
@@ -22,8 +22,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/signup", "/h2-console/**").permitAll()
-                        .anyRequest().authenticated()
+                    .requestMatchers("/**").permitAll()
                 )
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
 

--- a/src/main/java/com/sennyru/onboarding/controller/MemberController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.sennyru.onboarding.controller;
 
-import com.sennyru.onboarding.domain.Member;
 import com.sennyru.onboarding.dto.MemberResponseDto;
 import com.sennyru.onboarding.dto.SignupRequestDto;
 import com.sennyru.onboarding.service.MemberService;
@@ -22,8 +21,7 @@ public class MemberController {
 
     @PostMapping("/signup")
     public ResponseEntity<MemberResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-        Member savedMember = memberService.signup(requestDto);
-        MemberResponseDto responseDto = MemberResponseDto.from(savedMember);
+        MemberResponseDto responseDto = memberService.signup(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/controller/MemberController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.sennyru.onboarding.controller;
+
+import com.sennyru.onboarding.domain.Member;
+import com.sennyru.onboarding.dto.MemberResponseDto;
+import com.sennyru.onboarding.dto.SignupRequestDto;
+import com.sennyru.onboarding.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<MemberResponseDto> signup(@RequestBody SignupRequestDto requestDto) {
+        Member savedMember = memberService.signup(requestDto);
+        MemberResponseDto responseDto = new MemberResponseDto(savedMember);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/controller/MemberController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<MemberResponseDto> signup(@RequestBody SignupRequestDto requestDto) {
         Member savedMember = memberService.signup(requestDto);
-        MemberResponseDto responseDto = new MemberResponseDto(savedMember);
+        MemberResponseDto responseDto = MemberResponseDto.from(savedMember);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/controller/MemberController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.sennyru.onboarding.domain.Member;
 import com.sennyru.onboarding.dto.MemberResponseDto;
 import com.sennyru.onboarding.dto.SignupRequestDto;
 import com.sennyru.onboarding.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public ResponseEntity<MemberResponseDto> signup(@RequestBody SignupRequestDto requestDto) {
+    public ResponseEntity<MemberResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
         Member savedMember = memberService.signup(requestDto);
         MemberResponseDto responseDto = MemberResponseDto.from(savedMember);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);

--- a/src/main/java/com/sennyru/onboarding/domain/Member.java
+++ b/src/main/java/com/sennyru/onboarding/domain/Member.java
@@ -1,0 +1,38 @@
+package com.sennyru.onboarding.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Builder
+    public Member(String email, String password, String username) {
+        this.email = email;
+        this.password = password;
+        this.username = username;
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/domain/Member.java
+++ b/src/main/java/com/sennyru/onboarding/domain/Member.java
@@ -6,13 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(staticName = "create")
 public class Member {
 
     @Id
@@ -20,19 +22,15 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
+    @NonNull
     @Column(nullable = false, unique = true)
     private String email;
 
+    @NonNull
     @Column(nullable = false)
     private String password;
 
+    @NonNull
     @Column(nullable = false)
     private String username;
-
-    @Builder
-    public Member(String email, String password, String username) {
-        this.email = email;
-        this.password = password;
-        this.username = username;
-    }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/ErrorResponse.java
+++ b/src/main/java/com/sennyru/onboarding/dto/ErrorResponse.java
@@ -1,25 +1,15 @@
 package com.sennyru.onboarding.dto;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
-
 import java.time.LocalDateTime;
 
-@Getter
-public class ErrorResponse {
-
-    private final LocalDateTime time = LocalDateTime.now();
-    private final String status;
-    private final String message;
-    private final String requestURI;
-
-    private ErrorResponse(HttpStatus status, String message, String requestURI) {
-        this.status = status.name();
-        this.message = message;
-        this.requestURI = requestURI;
-    }
-
+public record ErrorResponse(
+    LocalDateTime time,
+    String status,
+    String message,
+    String requestURI
+) {
     public static ErrorResponse of(HttpStatus status, String message, String requestURI) {
-        return new ErrorResponse(status, message, requestURI);
+        return new ErrorResponse(LocalDateTime.now(), status.name(), message, requestURI);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/ErrorResponse.java
+++ b/src/main/java/com/sennyru/onboarding/dto/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.sennyru.onboarding.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+
+    private final LocalDateTime time = LocalDateTime.now();
+    private final String status;
+    private final String message;
+    private final String requestURI;
+
+    @Builder
+    public ErrorResponse(HttpStatus status, String message, String requestURI) {
+        this.status = status.name();
+        this.message = message;
+        this.requestURI = requestURI;
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/dto/ErrorResponse.java
+++ b/src/main/java/com/sennyru/onboarding/dto/ErrorResponse.java
@@ -1,6 +1,5 @@
 package com.sennyru.onboarding.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -14,10 +13,13 @@ public class ErrorResponse {
     private final String message;
     private final String requestURI;
 
-    @Builder
-    public ErrorResponse(HttpStatus status, String message, String requestURI) {
+    private ErrorResponse(HttpStatus status, String message, String requestURI) {
         this.status = status.name();
         this.message = message;
         this.requestURI = requestURI;
+    }
+
+    public static ErrorResponse of(HttpStatus status, String message, String requestURI) {
+        return new ErrorResponse(status, message, requestURI);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
@@ -1,9 +1,7 @@
 package com.sennyru.onboarding.dto;
 
-import com.sennyru.onboarding.domain.Member;
-
 public record MemberResponseDto(String email, String username) {
-    public static MemberResponseDto from(Member member) {
-        return new MemberResponseDto(member.getEmail(), member.getUsername());
+    public static MemberResponseDto of(String email, String username) {
+        return new MemberResponseDto(email, username);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
@@ -1,19 +1,9 @@
 package com.sennyru.onboarding.dto;
 
 import com.sennyru.onboarding.domain.Member;
-import lombok.Getter;
 
-@Getter
-public class MemberResponseDto {
-    private final String email;
-    private final String username;
-
-    private MemberResponseDto(Member member) {
-        this.email = member.getEmail();
-        this.username = member.getUsername();
-    }
-
+public record MemberResponseDto(String email, String username) {
     public static MemberResponseDto from(Member member) {
-        return new MemberResponseDto(member);
+        return new MemberResponseDto(member.getEmail(), member.getUsername());
     }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
@@ -1,0 +1,15 @@
+package com.sennyru.onboarding.dto;
+
+import com.sennyru.onboarding.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberResponseDto {
+    private String email;
+    private String username;
+
+    public MemberResponseDto(Member member) {
+        this.email = member.getEmail();
+        this.username = member.getUsername();
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/MemberResponseDto.java
@@ -5,11 +5,15 @@ import lombok.Getter;
 
 @Getter
 public class MemberResponseDto {
-    private String email;
-    private String username;
+    private final String email;
+    private final String username;
 
-    public MemberResponseDto(Member member) {
+    private MemberResponseDto(Member member) {
         this.email = member.getEmail();
         this.username = member.getUsername();
+    }
+
+    public static MemberResponseDto from(Member member) {
+        return new MemberResponseDto(member);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
@@ -1,0 +1,12 @@
+package com.sennyru.onboarding.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequestDto {
+    private String email;
+    private String password;
+    private String username;
+}

--- a/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
@@ -1,12 +1,20 @@
 package com.sennyru.onboarding.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class SignupRequestDto {
-    private String email;
-    private String password;
-    private String username;
+    private final String email;
+    private final String password;
+    private final String username;
+
+    private SignupRequestDto(String email, String password, String username) {
+        this.email = email;
+        this.password = password;
+        this.username = username;
+    }
+
+    public static SignupRequestDto of(String email, String password, String username) {
+        return new SignupRequestDto(email, password, username);
+    }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
@@ -1,11 +1,19 @@
 package com.sennyru.onboarding.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class SignupRequestDto {
+    @NotBlank
+    @Email
     private final String email;
+
+    @NotBlank
     private final String password;
+
+    @NotBlank
     private final String username;
 
     private SignupRequestDto(String email, String password, String username) {

--- a/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/SignupRequestDto.java
@@ -2,26 +2,18 @@ package com.sennyru.onboarding.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
 
-@Getter
-public class SignupRequestDto {
+public record SignupRequestDto(
     @NotBlank
     @Email
-    private final String email;
+    String email,
 
     @NotBlank
-    private final String password;
+    String password,
 
     @NotBlank
-    private final String username;
-
-    private SignupRequestDto(String email, String password, String username) {
-        this.email = email;
-        this.password = password;
-        this.username = username;
-    }
-
+    String username
+) {
     public static SignupRequestDto of(String email, String password, String username) {
         return new SignupRequestDto(email, password, username);
     }

--- a/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.sennyru.onboarding.handler;
+
+import com.sennyru.onboarding.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .message(ex.getMessage())
+                .requestURI(request.getRequestURI())
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
@@ -12,11 +12,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex, HttpServletRequest request) {
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .status(HttpStatus.BAD_REQUEST)
-                .message(ex.getMessage())
-                .requestURI(request.getRequestURI())
-                .build();
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.sennyru.onboarding.handler;
 
 import com.sennyru.onboarding.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,5 +15,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex, HttpServletRequest request) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 데이터베이스 UNIQUE 제약 조건 위반 시 발생하는 예외를 처리한다.
+     * (회원가입 시 이메일 중복과 같은 레이스 컨디션 상황 등)
+     * @param ex 발생한 예외
+     * @param request 예외가 발생한 요청
+     * @return 409 Conflict 상태 코드와 에러 메시지를 담은 응답
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.", request.getRequestURI());
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/repository/MemberRepository.java
+++ b/src/main/java/com/sennyru/onboarding/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import com.sennyru.onboarding.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/sennyru/onboarding/repository/MemberRepository.java
+++ b/src/main/java/com/sennyru/onboarding/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.sennyru.onboarding.repository;
+
+import com.sennyru.onboarding.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/sennyru/onboarding/service/MemberService.java
+++ b/src/main/java/com/sennyru/onboarding/service/MemberService.java
@@ -24,11 +24,7 @@ public class MemberService {
 
         String encryptedPassword = passwordEncoder.encode(requestDto.getPassword());
 
-        Member member = Member.builder()
-                .email(requestDto.getEmail())
-                .password(encryptedPassword)
-                .username(requestDto.getUsername())
-                .build();
+        Member member = Member.create(requestDto.getEmail(), encryptedPassword, requestDto.getUsername());
 
         return memberRepository.save(member);
     }

--- a/src/main/java/com/sennyru/onboarding/service/MemberService.java
+++ b/src/main/java/com/sennyru/onboarding/service/MemberService.java
@@ -1,0 +1,31 @@
+package com.sennyru.onboarding.service;
+
+import com.sennyru.onboarding.domain.Member;
+import com.sennyru.onboarding.dto.SignupRequestDto;
+import com.sennyru.onboarding.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Member signup(SignupRequestDto requestDto) {
+        String encryptedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        Member member = Member.builder()
+                .email(requestDto.getEmail())
+                .password(encryptedPassword)
+                .username(requestDto.getUsername())
+                .build();
+
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/service/MemberService.java
+++ b/src/main/java/com/sennyru/onboarding/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.sennyru.onboarding.service;
 
+import com.sennyru.onboarding.dto.MemberResponseDto;
 import com.sennyru.onboarding.domain.Member;
 import com.sennyru.onboarding.dto.SignupRequestDto;
 import com.sennyru.onboarding.repository.MemberRepository;
@@ -17,15 +18,15 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public Member signup(SignupRequestDto requestDto) {
+    public MemberResponseDto signup(SignupRequestDto requestDto) {
         if (memberRepository.existsByEmail(requestDto.email())) {
             throw new IllegalStateException("이미 가입된 이메일입니다.");
         }
 
         String encryptedPassword = passwordEncoder.encode(requestDto.password());
-
         Member member = Member.create(requestDto.email(), encryptedPassword, requestDto.username());
+        Member savedMember = memberRepository.save(member);
 
-        return memberRepository.save(member);
+        return MemberResponseDto.of(savedMember.getEmail(), savedMember.getUsername());
     }
 }

--- a/src/main/java/com/sennyru/onboarding/service/MemberService.java
+++ b/src/main/java/com/sennyru/onboarding/service/MemberService.java
@@ -18,6 +18,10 @@ public class MemberService {
 
     @Transactional
     public Member signup(SignupRequestDto requestDto) {
+        if (memberRepository.existsByEmail(requestDto.getEmail())) {
+            throw new IllegalStateException("이미 가입된 이메일입니다.");
+        }
+
         String encryptedPassword = passwordEncoder.encode(requestDto.getPassword());
 
         Member member = Member.builder()

--- a/src/main/java/com/sennyru/onboarding/service/MemberService.java
+++ b/src/main/java/com/sennyru/onboarding/service/MemberService.java
@@ -18,13 +18,13 @@ public class MemberService {
 
     @Transactional
     public Member signup(SignupRequestDto requestDto) {
-        if (memberRepository.existsByEmail(requestDto.getEmail())) {
+        if (memberRepository.existsByEmail(requestDto.email())) {
             throw new IllegalStateException("이미 가입된 이메일입니다.");
         }
 
-        String encryptedPassword = passwordEncoder.encode(requestDto.getPassword());
+        String encryptedPassword = passwordEncoder.encode(requestDto.password());
 
-        Member member = Member.create(requestDto.getEmail(), encryptedPassword, requestDto.getUsername());
+        Member member = Member.create(requestDto.email(), encryptedPassword, requestDto.username());
 
         return memberRepository.save(member);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
-spring.application.name=Onboarding
+# H2 Database
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:onboarding
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #1 

간단한 회원가입 API를 설계했습니다.

## 구현 내용
`/api/members/signup` URI에 아래와 같은 POST 요청을 보내면 DB에 회원 데이터가 저장되고 로그인 정보를 받습니다.

[예시 요청]
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
    "username" : "username"
}
```
[예시 응답]
```json
{
    "email" : "email@urssu.com",
    "username" : "username"
}
```


만약 이미 존재하는 이메일로 회원가입을 시도할 경우 아래와 같은 응답을 받습니다.
```json
{
  "status": "BAD_REQUEST",
  "message": "이미 가입된 이메일입니다.",
  "requestURI": "/api/members/signup",
  "time": "2025-09-25T02:24:26.0886478"
}
```

비밀번호는 Spring Security 라이브러리로 암호화하여 저장합니다.

## 종속성
- lombok, JPA, Spring Security, H2
- Spring Boot Validation은 아직 사용하지 않지만 미리 추가
