### PR TITLE
[#3]; feat: 게시물 생성, 수정, 삭제 기능 추가

### DIFF
--- a/src/main/java/com/sennyru/onboarding/controller/PostController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.sennyru.onboarding.controller;
 
+import com.sennyru.onboarding.dto.PostUpdateRequestDto;
 import com.sennyru.onboarding.dto.PostCreateRequestDto;
 import com.sennyru.onboarding.dto.PostResponseDto;
 import com.sennyru.onboarding.service.PostService;
@@ -7,7 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +26,11 @@ public class PostController {
     public ResponseEntity<PostResponseDto> createPost(@Valid @RequestBody PostCreateRequestDto requestDto) {
         PostResponseDto responseDto = postService.createPost(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequestDto requestDto) {
+        PostResponseDto responseDto = postService.updatePost(postId, requestDto);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/controller/PostController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.sennyru.onboarding.controller;
 
+import com.sennyru.onboarding.dto.PostDeleteRequestDto;
 import com.sennyru.onboarding.dto.PostUpdateRequestDto;
 import com.sennyru.onboarding.dto.PostCreateRequestDto;
 import com.sennyru.onboarding.dto.PostResponseDto;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,5 +34,11 @@ public class PostController {
     public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequestDto requestDto) {
         PostResponseDto responseDto = postService.updatePost(postId, requestDto);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @Valid @RequestBody PostDeleteRequestDto requestDto) {
+        postService.deletePost(postId, requestDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sennyru/onboarding/controller/PostController.java
+++ b/src/main/java/com/sennyru/onboarding/controller/PostController.java
@@ -1,0 +1,27 @@
+package com.sennyru.onboarding.controller;
+
+import com.sennyru.onboarding.dto.PostCreateRequestDto;
+import com.sennyru.onboarding.dto.PostResponseDto;
+import com.sennyru.onboarding.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostResponseDto> createPost(@Valid @RequestBody PostCreateRequestDto requestDto) {
+        PostResponseDto responseDto = postService.createPost(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/domain/Post.java
+++ b/src/main/java/com/sennyru/onboarding/domain/Post.java
@@ -1,0 +1,39 @@
+package com.sennyru.onboarding.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(staticName = "create")
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NonNull
+    @Column(nullable = false)
+    private String title;
+
+    @NonNull
+    @Column(nullable = false)
+    private String content;
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/sennyru/onboarding/domain/Post.java
+++ b/src/main/java/com/sennyru/onboarding/domain/Post.java
@@ -36,4 +36,9 @@ public class Post {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/sennyru/onboarding/dto/PostCreateRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/PostCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.sennyru.onboarding.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PostCreateRequestDto(
+    @NotBlank
+    @Email
+    String email,
+
+    @NotBlank
+    String password,
+
+    @NotBlank
+    String title,
+
+    @NotBlank
+    String content
+) {
+    public static PostCreateRequestDto of(String email, String password, String title, String content) {
+        return new PostCreateRequestDto(email, password, title, content);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/dto/PostDeleteRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/PostDeleteRequestDto.java
@@ -1,0 +1,17 @@
+package com.sennyru.onboarding.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PostDeleteRequestDto(
+    @NotBlank
+    @Email
+    String email,
+
+    @NotBlank
+    String password
+) {
+    public static PostDeleteRequestDto of(String email, String password) {
+        return new PostDeleteRequestDto(email, password);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/dto/PostResponseDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/PostResponseDto.java
@@ -1,0 +1,12 @@
+package com.sennyru.onboarding.dto;
+
+public record PostResponseDto(
+    Long articleId,
+    String email,
+    String title,
+    String content
+) {
+    public static PostResponseDto of(Long articleId, String email, String title, String content) {
+        return new PostResponseDto(articleId, email, title, content);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/sennyru/onboarding/dto/PostUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package com.sennyru.onboarding.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PostUpdateRequestDto(
+    @NotBlank
+    @Email
+    String email,
+
+    @NotBlank
+    String password,
+
+    @NotBlank
+    String title,
+
+    @NotBlank
+    String content
+) {
+    public static PostUpdateRequestDto of(String email, String password, String title, String content) {
+        return new PostUpdateRequestDto(email, password, title, content);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/exception/DomainException.java
+++ b/src/main/java/com/sennyru/onboarding/exception/DomainException.java
@@ -1,0 +1,14 @@
+package com.sennyru.onboarding.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DomainException extends RuntimeException {
+    private final HttpStatus status;
+
+    public DomainException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/sennyru/onboarding/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.sennyru.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EmailAlreadyExistsException extends DomainException {
+    public EmailAlreadyExistsException(String message) {
+        super(message, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/exception/InvalidPasswordException.java
+++ b/src/main/java/com/sennyru/onboarding/exception/InvalidPasswordException.java
@@ -1,0 +1,9 @@
+package com.sennyru.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidPasswordException extends DomainException {
+    public InvalidPasswordException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/exception/MemberNotFoundException.java
+++ b/src/main/java/com/sennyru/onboarding/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sennyru.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class MemberNotFoundException extends DomainException {
+    public MemberNotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/exception/PostAccessDeniedException.java
+++ b/src/main/java/com/sennyru/onboarding/exception/PostAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.sennyru.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PostAccessDeniedException extends DomainException {
+    public PostAccessDeniedException(String message) {
+        super(message, HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/exception/PostNotFoundException.java
+++ b/src/main/java/com/sennyru/onboarding/exception/PostNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sennyru.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PostNotFoundException extends DomainException {
+    public PostNotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
@@ -1,32 +1,17 @@
 package com.sennyru.onboarding.handler;
 
 import com.sennyru.onboarding.dto.ErrorResponse;
+import com.sennyru.onboarding.exception.DomainException;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
-    public ResponseEntity<ErrorResponse> handleBadRequestExceptions(RuntimeException ex, HttpServletRequest request) {
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
-
-    /**
-     * 데이터베이스 UNIQUE 제약 조건 위반 시 발생하는 예외를 처리한다.
-     * (회원가입 시 이메일 중복과 같은 레이스 컨디션 상황 등)
-     * @param ex 발생한 예외
-     * @param request 예외가 발생한 요청
-     * @return 409 Conflict 상태 코드와 에러 메시지를 담은 응답
-     */
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex, HttpServletRequest request) {
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.", request.getRequestURI());
-        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ErrorResponse> handleDomainException(DomainException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.of(ex.getStatus(), ex.getMessage(), request.getRequestURI());
+        return new ResponseEntity<>(errorResponse, ex.getStatus());
     }
 }

--- a/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sennyru/onboarding/handler/GlobalExceptionHandler.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex, HttpServletRequest request) {
+    @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
+    public ResponseEntity<ErrorResponse> handleBadRequestExceptions(RuntimeException ex, HttpServletRequest request) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/sennyru/onboarding/repository/MemberRepository.java
+++ b/src/main/java/com/sennyru/onboarding/repository/MemberRepository.java
@@ -3,6 +3,10 @@ package com.sennyru.onboarding.repository;
 import com.sennyru.onboarding.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/sennyru/onboarding/repository/PostRepository.java
+++ b/src/main/java/com/sennyru/onboarding/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.sennyru.onboarding.repository;
+
+import com.sennyru.onboarding.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/sennyru/onboarding/service/PostService.java
+++ b/src/main/java/com/sennyru/onboarding/service/PostService.java
@@ -1,5 +1,6 @@
 package com.sennyru.onboarding.service;
 
+import com.sennyru.onboarding.dto.PostDeleteRequestDto;
 import com.sennyru.onboarding.dto.PostUpdateRequestDto;
 import com.sennyru.onboarding.domain.Member;
 import com.sennyru.onboarding.domain.Post;
@@ -67,5 +68,24 @@ public class PostService {
             post.getTitle(),
             post.getContent()
         );
+    }
+
+    @Transactional
+    public void deletePost(Long postId, PostDeleteRequestDto requestDto) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
+
+        Member member = memberRepository.findByEmail(requestDto.email())
+            .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        if (!Objects.equals(post.getMember().getId(), member.getId())) {
+            throw new IllegalStateException("게시물 삭제 권한이 없습니다.");
+        }
+
+        postRepository.delete(post);
     }
 }

--- a/src/main/java/com/sennyru/onboarding/service/PostService.java
+++ b/src/main/java/com/sennyru/onboarding/service/PostService.java
@@ -1,11 +1,11 @@
 package com.sennyru.onboarding.service;
 
-import com.sennyru.onboarding.dto.PostDeleteRequestDto;
-import com.sennyru.onboarding.dto.PostUpdateRequestDto;
 import com.sennyru.onboarding.domain.Member;
 import com.sennyru.onboarding.domain.Post;
 import com.sennyru.onboarding.dto.PostCreateRequestDto;
+import com.sennyru.onboarding.dto.PostDeleteRequestDto;
 import com.sennyru.onboarding.dto.PostResponseDto;
+import com.sennyru.onboarding.dto.PostUpdateRequestDto;
 import com.sennyru.onboarding.repository.MemberRepository;
 import com.sennyru.onboarding.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +26,7 @@ public class PostService {
 
     @Transactional
     public PostResponseDto createPost(PostCreateRequestDto requestDto) {
-        Member member = memberRepository.findByEmail(requestDto.email())
-            .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
-
-        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
+        Member member = authenticateMember(requestDto.email(), requestDto.password());
 
         Post post = Post.create(requestDto.title(), requestDto.content(), member);
         Post savedPost = postRepository.save(post);
@@ -46,19 +41,8 @@ public class PostService {
 
     @Transactional
     public PostResponseDto updatePost(Long postId, PostUpdateRequestDto requestDto) {
-        Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
-
-        Member member = memberRepository.findByEmail(requestDto.email())
-            .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
-
-        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
-
-        if (!Objects.equals(post.getMember().getId(), member.getId())) {
-            throw new IllegalStateException("게시물 수정 권한이 없습니다.");
-        }
+        Member member = authenticateMember(requestDto.email(), requestDto.password());
+        Post post = findPostAndValidateOwnership(postId, member);
 
         post.update(requestDto.title(), requestDto.content());
 
@@ -72,20 +56,45 @@ public class PostService {
 
     @Transactional
     public void deletePost(Long postId, PostDeleteRequestDto requestDto) {
+        Member member = authenticateMember(requestDto.email(), requestDto.password());
+        Post post = findPostAndValidateOwnership(postId, member);
+
+        postRepository.delete(post);
+    }
+    
+    
+    /**
+     * 이메일이 가입되어 있고 비밀번호가 일치한지 검증합니다.
+     * @param email 사용자 이메일
+     * @param password 평문 비밀번호
+     * @return 검증된 Member 엔티티
+     * @throws IllegalArgumentException 가입되지 않은 이메일이거나 비밀번호가 일치하지 않을 경우
+     */
+    private Member authenticateMember(String email, String password) {
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+        return member;
+    }
+
+    /**
+     * 게시물이 존재하는지 확인하고, 사용자가 게시물의 작성자인지 검증합니다.
+     * @param postId 확인할 게시물의 ID
+     * @param member (인증된) 사용자 Member 엔티티
+     * @return 검증된 Post 엔티티
+     * @throws IllegalArgumentException 게시물이 존재하지 않을 경우
+     * @throws IllegalStateException 게시물에 대한 권한이 없을 경우
+     */
+    private Post findPostAndValidateOwnership(Long postId, Member member) {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
 
-        Member member = memberRepository.findByEmail(requestDto.email())
-            .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
-
-        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
-
         if (!Objects.equals(post.getMember().getId(), member.getId())) {
-            throw new IllegalStateException("게시물 삭제 권한이 없습니다.");
+            throw new IllegalStateException("게시물에 대한 권한이 없습니다.");
         }
-
-        postRepository.delete(post);
+        return post;
     }
 }

--- a/src/main/java/com/sennyru/onboarding/service/PostService.java
+++ b/src/main/java/com/sennyru/onboarding/service/PostService.java
@@ -1,0 +1,42 @@
+package com.sennyru.onboarding.service;
+
+import com.sennyru.onboarding.domain.Member;
+import com.sennyru.onboarding.domain.Post;
+import com.sennyru.onboarding.dto.PostCreateRequestDto;
+import com.sennyru.onboarding.dto.PostResponseDto;
+import com.sennyru.onboarding.repository.MemberRepository;
+import com.sennyru.onboarding.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public PostResponseDto createPost(PostCreateRequestDto requestDto) {
+        Member member = memberRepository.findByEmail(requestDto.email())
+            .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        Post post = Post.create(requestDto.title(), requestDto.content(), member);
+        Post savedPost = postRepository.save(post);
+
+        return PostResponseDto.of(
+            savedPost.getId(),
+            savedPost.getMember().getEmail(),
+            savedPost.getTitle(),
+            savedPost.getContent()
+        );
+    }
+}


### PR DESCRIPTION
Closes #3

# 구현 내용
API 명세는 README.md를 참고해 주세요.

## 게시물 생성
`/api/posts`로 POST 요청을 보내면 DB에 게시물이 생성됩니다.
사용자 ID가 존재하지 않거나, PW가 맞지 않는 경우 400 Bad Request를 보냅니다.
성공하면 201 Created를 보냅니다.

## 게시물 수정
`/api/posts/{게시물 ID}`로 PUT 요청을 보내면 DB에 있는 게시물의 제목과 내용이 수정됩니다.
게시물 ID가 존재하지 않거나, 사용자 ID가 존재하지 않거나, PW가 맞지 않거나, 게시물 작성자가 그 사용자가 아닐 경우 400 Bad Request를 보냅니다.
성공하면 200 Ok를 보냅니다.

## 게시물 삭제
`/api/posts/{게시물 ID`로 DELETE 요청을 보내면 DB에 있는 게시물이 삭제됩니다.
게시물 ID가 존재하지 않거나, 사용자 ID가 존재하지 않거나, PW가 맞지 않거나, 게시물 작성자가 그 사용자가 아닐 경우 400 Bad Request를 보냅니다.
성공하면 204 No Content를 보냅니다.

# 느낀 점
회원가입(#2) 만들 때 기본적인 틀을 다 만들어 놓은 상태라서 추가 기능을 구현하는 데 별로 어려움이 없었다.

# 새로 알게 된 것들
- 외래 키 지정
- Path Variable
- POST 이외의 다른 HTTP 요청들